### PR TITLE
MOOV-4718. Google places new api (autocomplete service)

### DIFF
--- a/src/GoogleMaps.php
+++ b/src/GoogleMaps.php
@@ -23,8 +23,10 @@ class GoogleMaps extends WebService
      * @return \GoogleMaps\WebService
      * @throws \ErrorException
      */
-    public function load($service)
+    public function load($service, $version = null)
     {
+        $this->version = $version;
+
         // Is overwrite class specified
         $class = array_key_exists($service, $this->webServices) ? new $this->webServices[$service] : $this;
         $class->build($service);

--- a/src/WebService.php
+++ b/src/WebService.php
@@ -313,13 +313,12 @@ class WebService{
      * @return object
      * @throws \ErrorException
      */
-    protected function make($isPost = false, $httpHeaders = [])
+    protected function make($isPost)
     {
-        $headers = array_merge($httpHeaders, $this->headers);
         $ch = curl_init($this->requestUrl);
 
         if ($isPost) {
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $this->headers);
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $isPost);
         }

--- a/src/config/googlemaps.php
+++ b/src/config/googlemaps.php
@@ -350,9 +350,21 @@ return [
                                                     ]
         ],
 
-
-
-
+        'new_placeautocomplete' => [
+            'url'                   => 'https://places.googleapis.com/v1/places:autocomplete',
+            'type'                  => 'POST',
+            'key'                   =>  null,
+            'endpoint'              =>  true,
+            'responseDefaultKey'    => 'placePrediction',
+            'param'                 => [
+                                        'input'                 => null,
+                                        'inputOffset'           => null,
+                                        'locationBias'          => null,
+                                        'languageCode'          => null,
+                                        'includedPrimaryTypes'  => null,
+                                        'includedRegionCodes'   => null,
+                                        ]
+        ],
 
         'placeautocomplete' => [
                         'url'                   => 'https://maps.googleapis.com/maps/api/place/autocomplete/',


### PR DESCRIPTION
Google sacó una nueva versión de la API de Places:
https://developers.google.com/maps/documentation/places/web-service/op-overview?hl=es-419

Por este motivo, debemos migrar los endpoints que usamos de la versión anterior, a la nueva.
Para realizar requests a dicha API, usamos este fork de un paquete.
Lo que hacemos acá, es simplemente "agregar" el nuevo servicio para luego poder usarlo desde core-api.
Hay nuchos cambios de CS que no voy a comentar en el PR.